### PR TITLE
Fix make install build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,17 @@
+.PHONY: build install clean test
+
+# Build binary for local testing
 build:
 	go build -o whoseport .
 
-install: build
-	cp whoseport $$GOPATH/bin/ && rm ./whoseport
+# Install binary to $GOBIN (or $GOPATH/bin or $HOME/go/bin)
+install:
+	go install .
+
+# Remove locally built binary
+clean:
+	rm -f whoseport
+
+# Run tests
+test:
+	go test ./...

--- a/README.md
+++ b/README.md
@@ -8,15 +8,32 @@ This will run on Unix machines (anywhere that `lsof` exists)
 
 ### Installing
 
-If you have go, you can run
+#### Using Go Install (Recommended)
 
-```go get -u github.com/bluehoodie/whoseport```
+If you have Go installed:
 
-Or you can download and compile from source by downloading and using
+```bash
+go install github.com/bluehoodie/whoseport@latest
+```
 
-```make install```
+This will install the binary to your `$GOBIN` directory (or `$GOPATH/bin`, or `$HOME/go/bin` by default).
 
-If you do not have go, downloads will be available shortly.
+#### From Source
+
+Clone the repository and install:
+
+```bash
+git clone https://github.com/bluehoodie/whoseport.git
+cd whoseport
+make install
+```
+
+Or just build locally for testing:
+
+```bash
+make build
+./whoseport 8080
+```
 
 ### Usage
 


### PR DESCRIPTION
- Replace manual build+copy with `go install` command
- Add .PHONY declarations and additional Make targets (clean, test)
- Update README with modern Go installation instructions
- Document go install as recommended method
- Provide clearer from-source build instructions

The previous approach of building and manually copying to $GOPATH/bin was not idiomatic. Using `go install` is the standard Go way to install binaries, and it handles GOBIN/GOPATH automatically.

Generated with [Claude Code](https://claude.com/claude-code)